### PR TITLE
Use IExtendedBus for CreateBus Return Value

### DIFF
--- a/Bus.d.ts
+++ b/Bus.d.ts
@@ -1,6 +1,6 @@
 import * as bbPromise from 'bluebird';
 export declare class RabbitHutch {
-    static CreateBus(config: IBusConfig): IBus;
+    static CreateBus(config: IBusConfig): IExtendedBus;
 }
 export declare class Bus implements IExtendedBus {
     config: IBusConfig;
@@ -174,11 +174,7 @@ export interface IExtendedBus extends IBus {
     DeleteQueueUnconditional(queue: string): bbPromise<{
         messageCount: number;
     }>;
-    QueueStatus(queue: string): bbPromise<{
-        queue: string;
-        messageCount: number;
-        consumerCount: number;
-    }>;
+    QueueStatus(queue: string): bbPromise<IQueueStats>;
 }
 export interface IQueueConsumeReply {
     consumerTag: string;
@@ -186,4 +182,9 @@ export interface IQueueConsumeReply {
 export interface IConsumerDispose {
     cancelConsumer: () => bbPromise<boolean>;
     deleteQueue: () => bbPromise<boolean>;
+}
+export interface IQueueStats {
+    queue: string;
+    messageCount: number;
+    consumerCount: number;
 }

--- a/Bus.ts
+++ b/Bus.ts
@@ -5,7 +5,7 @@ import * as uuid from 'node-uuid';
 
 
 export class RabbitHutch {
-    public static CreateBus(config: IBusConfig): IBus {
+    public static CreateBus(config: IBusConfig): IExtendedBus {
         var bus = new Bus(config);
         return bus;
     }
@@ -544,7 +544,7 @@ export interface IExtendedBus extends IBus {
     DeleteExchange(exchange: string, ifUnused: boolean): void;
     DeleteQueue(queue: string, ifUnused: boolean, ifEmpty: boolean): bbPromise<{ messageCount: number }>;
     DeleteQueueUnconditional(queue: string): bbPromise<{ messageCount: number }>;
-    QueueStatus(queue: string): bbPromise<{ queue: string; messageCount: number; consumerCount: number; }>;
+    QueueStatus(queue: string): bbPromise<IQueueStats>;
 }
 
 interface IPublishedObj {
@@ -560,4 +560,10 @@ export interface IQueueConsumeReply {
 export interface IConsumerDispose {
     cancelConsumer: () => bbPromise<boolean>;
     deleteQueue: () => bbPromise<boolean>;
+}
+
+export interface IQueueStats {
+    queue: string;
+    messageCount: number;
+    consumerCount: number;
 }


### PR DESCRIPTION
The definition of `Bus` already implements `IExtendedBus` anyway, so let's just use that instead of `IBus`.

Also added an interface for queue stats.
